### PR TITLE
added dsniff package to Dockerfile.local-dns.attacker.student

### DIFF
--- a/labs/local-dns/dockerfiles/Dockerfile.local-dns.attacker.student
+++ b/labs/local-dns/dockerfiles/Dockerfile.local-dns.attacker.student
@@ -29,7 +29,7 @@ ARG password
 ARG apt_source
 ENV APT_SOURCE $apt_source
 RUN /usr/bin/apt-source.sh
-RUN apt-get update && apt-get install -y --no-install-recommends netwox
+RUN apt-get update && apt-get install -y --no-install-recommends netwox dsniff
 #
 # Install the system files found in the _system directory
 #


### PR DESCRIPTION
for issue #97 this package contains the missing arpspoof command