### PR TITLE
Student artifacts: populate the home_tar manifest; do not archive the primary user's tree twice

### DIFF
--- a/scripts/labtainer-student/bin/CheckTars.py
+++ b/scripts/labtainer-student/bin/CheckTars.py
@@ -158,7 +158,7 @@ def CheckTars(container_dir, image_name, logger):
                     os.chdir(tmp_loc)
                     full_tar = os.path.join(full, tar_name)
                     if f == 'home_tar':
-                        cmd = 'tar czf %s --owner=:1000 --group=:1000 `ls -A -1` > %s' % (full_tar, manifest)
+                        cmd = 'tar czvf %s --owner=:1000 --group=:1000 `ls -A -1` > %s' % (full_tar, manifest)
                     else:
                         cmd = 'tar czf %s --owner=root --group=root `ls -A -1`' % (full_tar)
                     os.system(cmd)
@@ -192,7 +192,7 @@ def CheckTars(container_dir, image_name, logger):
                     os.chdir(tmp_loc)
                     full_tar = os.path.join(full, tar_name)
                     if f == 'home_tar':
-                        cmd = 'tar czf %s `ls -A -1` > %s' % (full_tar, manifest)
+                        cmd = 'tar czvf %s `ls -A -1` > %s' % (full_tar, manifest)
                     else:
                         cmd = 'tar czf %s `ls -A -1`' % (full_tar)
                     os.system(cmd)

--- a/scripts/labtainer-student/lab_bin/Student.py
+++ b/scripts/labtainer-student/lab_bin/Student.py
@@ -81,7 +81,9 @@ def otherUsers(start_time, zipoutput, studentHomeDir, skip_list, dt_skip_list, s
     udir = '/home'
     os.chdir('/home')
     for rootdir, subdirs, files in os.walk(udir):
-            if rootdir == studentHomeDir:
+            # the primary user's tree is archived by main(); walking into it here duplicated every
+            # deliverable under other_users/<primary user>/ (os.walk descends past the top match)
+            if rootdir == studentHomeDir or rootdir.startswith(studentHomeDir + '/'):
                 continue
             newdir = rootdir.replace(udir, '.')
             # TBD FIX this


### PR DESCRIPTION
Two small fixes in the student-artifact path (stoplab -> .lab archive), found while auditing what our students' archives contain.

1. **CheckTars.py**: the per-image `home_tar` manifest (`config/<image>-home_tar.list`) is written from the stdout of `tar czf ...`, which prints nothing, so the manifest is always empty and `Student.py` never skips the `home_tar` seed files the lab designer guide (\"Large or numerous files in the home directory\") says are excluded. `tar czvf` produces the list. This matters whenever the image is built the same day the lab is started (designer/instructor test runs); for older images the modify-time rule already hides them.

2. **Student.py `otherUsers()`**: it skips only the exact primary-user home directory and then `os.walk` descends into its subdirectories, so every file under the primary user's home is archived a second time under `other_users/<primary user>/`. Skip the whole subtree.

Both verified on Ubuntu 24.04 (noble) containers: the archive now holds the student's edited deliverables once, plus `.local/result` and bash histories, and no seed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQfHVX14NCvhJwMM4BqDpL